### PR TITLE
iOS 11 compatibility

### DIFF
--- a/ARKitCompassRose/ViewController.swift
+++ b/ARKitCompassRose/ViewController.swift
@@ -33,7 +33,7 @@ class ViewController: UIViewController, ARSCNViewDelegate {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        let configuration = ARWorldTrackingSessionConfiguration()
+        let configuration = ARWorldTrackingConfiguration()
         // Align the real world on z(North-South) x(West-East) axis
         configuration.worldAlignment = .gravityAndHeading
         


### PR DESCRIPTION
iOS 11 replaces
`ARWorldTrackingSessionConfiguration`
with
`ARWorldTrackingConfiguration`
and this is a small update to bring the app up to date.